### PR TITLE
Handle all push routes

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -36,6 +36,7 @@ return [
 			'name' => 'UnifiedPushProvider#push',
 			'url' => '/push/{token}',
 			'verb' => 'POST',
+                        'requirements' => array('token' => '.*'),
 		],
 		[
 			'name' => 'UnifiedPushProvider#unifiedpushDiscovery',

--- a/lib/Controller/UnifiedPushProviderController.php
+++ b/lib/Controller/UnifiedPushProviderController.php
@@ -60,6 +60,7 @@ class UnifiedPushProviderController extends Controller {
 	function _push(string $token, string $message){
 		$redis = $this->redisFactory->getInstance();
 
+                $token = explode("/", $token)[0];
 		$query = $this->db->getQueryBuilder();
 		$query->select('*')
 			->from('uppush_applications')


### PR DESCRIPTION
Hi! 👋 

First things first: I discovered UnifiedPush and NextPush about two weeks ago and I'm very enthusiastic about it. Thank you for all your effort so far!

Right now I was playing a bit with porting UnifiedPush to other applications and therefore would propose two changes:

1. a5709dfe1665bc1194a87efd0ea9356ce5347260 so that every push request is forwarded to the controller, even if something is appended after the UUID. This also allows proper error messages.
2. 97e3e59c246e884caab72896b3de5486a43a8114 to extract the UUID from the path and try continue with that. This is very helpful as the server side of application may append something to the endpoint provided by UnifiedPush. This would enable better compatibility for such cases. As far as I can tell this is not contradicting the specification.

However, I'm open for feedback and discussion on this. 😊